### PR TITLE
Implement RestController for Book

### DIFF
--- a/src/main/java/com/groupseven/sysc4806project/Book.java
+++ b/src/main/java/com/groupseven/sysc4806project/Book.java
@@ -1,5 +1,6 @@
 package com.groupseven.sysc4806project;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -60,11 +61,12 @@ public class Book {
     }
 
     @Transient
-    public String getImage() {
+    public String getImageUrl() {
         return "/" + id + ".png";
     }
 
     @Transient
+    @JsonIgnore
     public boolean setImage(MultipartFile image) {
         Path savePath = Paths.get(IMAGE_DIR + id + ".png");
 
@@ -84,6 +86,21 @@ public class Book {
             return false;
         }
 
+        return true;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean removeImage() {
+        Path savePath = Paths.get(IMAGE_DIR + id + ".png");
+        if (Files.exists(savePath)) {
+            try {
+                Files.delete(savePath);
+            } catch (IOException e) {
+                e.printStackTrace();
+                return false;
+            }
+        }
         return true;
     }
 
@@ -111,4 +128,12 @@ public class Book {
         return publisher;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Book b)) {
+            return false;
+        }
+
+        return b.getId() == this.id;
+    }
 }

--- a/src/main/java/com/groupseven/sysc4806project/Book.java
+++ b/src/main/java/com/groupseven/sysc4806project/Book.java
@@ -3,13 +3,22 @@ package com.groupseven.sysc4806project;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 @Entity
 public class Book {
+    private static final String IMAGE_DIR = "resources/static/";
+
     private int id;
     private int inventory;
-
-
 
     private String isbn, description, title, author, publisher;
 
@@ -44,14 +53,40 @@ public class Book {
         this.publisher = publisher;
     }
 
-
     @Id
     @GeneratedValue
     public int getId() {
         return id;
     }
 
-    public String image() {return "";}
+    @Transient
+    public String getImage() {
+        return "/" + id + ".png";
+    }
+
+    @Transient
+    public boolean setImage(MultipartFile image) {
+        Path savePath = Paths.get(IMAGE_DIR + id + ".png");
+
+        if (!Files.exists(savePath)) {
+            try {
+                Files.createDirectories(savePath);
+            } catch (IOException e) {
+                e.printStackTrace();
+                return false;
+            }
+        }
+
+        try (InputStream is = image.getInputStream()) {
+            Files.copy(is, savePath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        return true;
+    }
+
     public int getInventory() {
         return inventory;
     }

--- a/src/main/java/com/groupseven/sysc4806project/BookRepository.java
+++ b/src/main/java/com/groupseven/sysc4806project/BookRepository.java
@@ -1,0 +1,6 @@
+package com.groupseven.sysc4806project;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface BookRepository extends CrudRepository<Book, Integer> {
+}

--- a/src/main/java/com/groupseven/sysc4806project/BookService.java
+++ b/src/main/java/com/groupseven/sysc4806project/BookService.java
@@ -1,0 +1,109 @@
+package com.groupseven.sysc4806project;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/books")
+public class BookService {
+    private final BookRepository repo;
+
+    @Autowired
+    public BookService(BookRepository repo) {
+        this.repo = repo;
+    }
+
+    @GetMapping("")
+    public List<Book> list() {
+        List<Book> books = new ArrayList<>();
+        this.repo.findAll().iterator().forEachRemaining(books::add);
+        return books;
+    }
+
+    @GetMapping("/{bookId}")
+    public Book get(@PathVariable Integer bookId) {
+        return this.repo.findById(bookId).orElse(null);
+    }
+
+    @PostMapping("")
+    public Boolean create(
+            @RequestParam String isbn,
+            @RequestParam String title,
+            @RequestParam(defaultValue = "") String description,
+            @RequestParam String author,
+            @RequestParam String publisher,
+            @RequestParam(defaultValue = "0") Integer inventory,
+            @RequestParam(required = false) MultipartFile image
+    ) {
+        Book newBook = new Book();
+        newBook.setIsbn(isbn);
+        newBook.setTitle(title);
+        newBook.setDescription(description);
+        newBook.setAuthor(author);
+        newBook.setPublisher(publisher);
+        newBook.setInventory(inventory);
+
+        this.repo.save(newBook);
+
+        if (image != null) {
+            return newBook.setImage(image);
+        }
+
+        return true;
+    }
+
+    @PatchMapping("/{bookId}")
+    public Boolean update(
+        @PathVariable Integer bookId,
+        @RequestParam(required = false) String isbn,
+        @RequestParam(required = false) String title,
+        @RequestParam(required = false) String description,
+        @RequestParam(required = false) String author,
+        @RequestParam(required = false) String publisher,
+        @RequestParam(required = false) Integer inventory,
+        @RequestParam(required = false) MultipartFile image
+    ) {
+        Optional<Book> bookOptional = this.repo.findById(bookId);
+        if (bookOptional.isEmpty()) {
+            // Could not find book with given ID
+            return false;
+        }
+
+        Book book = bookOptional.get();
+
+        if (isbn != null) {
+            book.setIsbn(isbn);
+        }
+
+        if (title != null) {
+            book.setTitle(title);
+        }
+
+        if (description != null) {
+            book.setDescription(description);
+        }
+
+        if (author != null) {
+            book.setAuthor(author);
+        }
+
+        if (publisher != null) {
+            book.setPublisher(publisher);
+        }
+
+        if (inventory != null) {
+            book.setInventory(inventory);
+        }
+
+        if (image != null) {
+            return book.setImage(image);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/groupseven/sysc4806project/BookService.java
+++ b/src/main/java/com/groupseven/sysc4806project/BookService.java
@@ -31,7 +31,7 @@ public class BookService {
     }
 
     @PostMapping("")
-    public Boolean create(
+    public Integer create(
             @RequestParam String isbn,
             @RequestParam String title,
             @RequestParam(defaultValue = "") String description,
@@ -51,13 +51,13 @@ public class BookService {
         this.repo.save(newBook);
 
         if (image != null) {
-            return newBook.setImage(image);
+            newBook.setImage(image);
         }
 
-        return true;
+        return newBook.getId();
     }
 
-    @PatchMapping("/{bookId}")
+    @PostMapping("/{bookId}")
     public Boolean update(
         @PathVariable Integer bookId,
         @RequestParam(required = false) String isbn,
@@ -100,10 +100,29 @@ public class BookService {
             book.setInventory(inventory);
         }
 
+        this.repo.save(book);
+
         if (image != null) {
             return book.setImage(image);
         }
 
+        return true;
+    }
+
+    @DeleteMapping("/{bookId}")
+    public Boolean delete(@PathVariable Integer bookId) {
+        Optional<Book> bookOptional = this.repo.findById(bookId);
+        if (bookOptional.isEmpty()) {
+            // Could not find book with given ID
+            return false;
+        }
+
+        Book b = bookOptional.get();
+
+        // Free up image file
+        b.removeImage();
+
+        this.repo.delete(bookOptional.get());
         return true;
     }
 }


### PR DESCRIPTION
Adds RestController functionality for Book. Active at `/api/books`.

Functions:

- `GET /api/books`: List all books
- `POST /api/books`: Add a new book (must specify ISBN, title, author, and publisher)
- `GET /api/books/{bookId}`: View book details
- `POST /api/books/{bookId}`: Update book details (can specify as many or as few options as you want)
- `DELETE /api/books/{bookId}`: Delete an existing book

Pages that display a book's info will have a default image if none is specified, but that has not yet been implemented.
I will have to circle back and create more tests for the image functionality once that's done.

#10 