### PR TITLE
Fix error messages on server launch

### DIFF
--- a/src/main/java/com/groupseven/sysc4806project/User.java
+++ b/src/main/java/com/groupseven/sysc4806project/User.java
@@ -1,11 +1,9 @@
 package com.groupseven.sysc4806project;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 
 @Entity
+@Table(name = "users")
 public class User {
     private int user_ID;
     private boolean isAdmin;


### PR DESCRIPTION
I noticed we get a bunch of error messages when launching the server. It doesn't impact functionality, but it does clutter the logs.

I tracked it down to being due to JPA trying to create a "user" table when it already exists thanks to [this link](https://stackoverflow.com/a/49573003). Simply added a `@Table(name = "users")` to make it generate a "users" table instead and there is no more conflict.