### PR TITLE
Change DB to sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ mvnw
 mvnw.cmd
 !**/src/main/**/target/
 !**/src/test/**/target/
+data.sqlite
 
 ### STS ###
 .apt_generated

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -37,14 +36,20 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.xerial</groupId>
+			<artifactId>sqlite-jdbc</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-community-dialects</artifactId>
+			<version>6.1.6.Final</version>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:sqlite:data.sqlite
+spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Move from H2 to sqlite to see the schema generated by JPA

Details:

- DB added to .gitignore to avoid cluttering commits
- sqlite JDBC driver added to pom
- Hibernate does not natively support sqlite, so the community dialects artifact was added to pom to enable this
- `spring.datasource.url` points Spring to the DB file
- `spring.jpa.database-platform` tells Spring to use the sqlite community dialect to interact with the DB
- `spring.jpa.hibernate.ddl-auto` tells Spring to update the DB schema whenever we make changes