### PR TITLE
Run tests in memory DB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
 			<scope>runtime</scope>

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Quick fix to avoid having our tests clutter the runtime DB. H2 has been added back into the project for tests. Once tests finish, the H2 database is dropped from memory and the app falls back on SQLite.

Closes #27 